### PR TITLE
Add '--atomic' flag to 'helm upgrade' command

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -90,5 +90,5 @@ jobs:
         run: "envsubst < values.yaml > values_sub.yaml && mv values_sub.yaml values.yaml"
       - uses: WyriHaximus/github-action-helm3@v2
         with:
-          exec: helm upgrade backend . --install --namespace=wooglife
+          exec: helm upgrade backend . --install --namespace=wooglife --atomic
           kubeconfig: '${{ secrets.KUBECONFIG_RAW }}'


### PR DESCRIPTION
`--atomic` makes sure that the deployment will actually start and rollback to the previous helm version if the new version fails.

```
helm upgrade --help | grep atomic
      --atomic                       if set, upgrade process rolls back changes made in case of failed upgrade. The --wait flag will be set automatically if --atomic is used
```